### PR TITLE
Added windows filtering platform events

### DIFF
--- a/data_dictionaries/windows/security/events/event-5031.md
+++ b/data_dictionaries/windows/security/events/event-5031.md
@@ -8,8 +8,8 @@ This event generates when an application was blocked from accepting incoming con
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-||Profiles|UnicodeString|Network profile using which application was blocked.|Domain|
-|process_path|Application|UnicodeString|Full path and file name of executable file for blocked application.|C:\\documents\\listener.exe|
+||Profiles|string|Network profile using which application was blocked.|Domain|
+|process_path|Application|string|Full path and file name of executable file for blocked application.|C:\\documents\\listener.exe|
 
 ## Reference
 

--- a/data_dictionaries/windows/security/events/event-5031.md
+++ b/data_dictionaries/windows/security/events/event-5031.md
@@ -9,7 +9,7 @@ This event generates when an application was blocked from accepting incoming con
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 ||Profiles|UnicodeString|Network profile using which application was blocked.|Domain|
-|file_path|Application|UnicodeString|Full path and file name of executable file for blocked application.|C:\\documents\\listener.exe|
+|process_path|Application|UnicodeString|Full path and file name of executable file for blocked application.|C:\\documents\\listener.exe|
 
 ## Reference
 

--- a/data_dictionaries/windows/security/events/event-5031.md
+++ b/data_dictionaries/windows/security/events/event-5031.md
@@ -1,0 +1,16 @@
+# Event ID 5031: The Windows Firewall Service blocked an application from accepting incoming connections on the network
+
+## Description
+
+This event generates when an application was blocked from accepting incoming connections on the network by Windows Filtering Platform. If you don’t have any firewall rules (Allow or Deny) in Windows Firewall for specific applications, you will get this event from Windows Filtering Platform layer, because by default this layer is denying any incoming connections.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+||Profiles|UnicodeString|Network profile using which application was blocked.|Domain|
+|file_path|Application|UnicodeString|Full path and file name of executable file for blocked application.|C:\\documents\\listener.exe|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5031.md)

--- a/data_dictionaries/windows/security/events/event-5154.md
+++ b/data_dictionaries/windows/security/events/event-5154.md
@@ -9,10 +9,10 @@ This event generates every time Windows Filtering Platform permits an applicatio
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 |process_id|ProcessId|Pointer|hexadecimal Process ID of the process which was permitted to listen on the port.|4152|
-|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
 |src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application requested to listen on the port.|0.0.0.0|
 |src_port|SourcePort|UnicodeString|Source TCP\UDP port number which was requested for listening by application.|44|
-||Protocol|UInt32|Protocol number.|6|
+|network_protocol|Protocol|UInt32|Protocol number.|6|
 ||FilterRTID|UInt64|Unique filter ID which allows application to listen on the specific port.|0|
 ||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
 ||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|

--- a/data_dictionaries/windows/security/events/event-5154.md
+++ b/data_dictionaries/windows/security/events/event-5154.md
@@ -8,14 +8,14 @@ This event generates every time Windows Filtering Platform permits an applicatio
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-|process_id|ProcessId|Pointer|hexadecimal Process ID of the process which was permitted to listen on the port.|4152|
-|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
-|src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application requested to listen on the port.|0.0.0.0|
-|src_port|SourcePort|UnicodeString|Source TCP\UDP port number which was requested for listening by application.|44|
-|network_protocol|Protocol|UInt32|Protocol number.|6|
-||FilterRTID|UInt64|Unique filter ID which allows application to listen on the specific port.|0|
-||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
-||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|
+|process_id|ProcessId|integer|hexadecimal Process ID of the process which was permitted to listen on the port.|4152|
+|process_path|Application|UnicostringdeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|src_ip_addr|SourceAddress|ip|Local IP address on which application requested to listen on the port.|0.0.0.0|
+|src_port|SourcePort|integer|Source TCP\UDP port number which was requested for listening by application.|44|
+|network_protocol|Protocol|integer|Protocol number.|6|
+||FilterRTID|integer|Unique filter ID which allows application to listen on the specific port.|0|
+||LayerName|string|Application Layer Enforcement layer name.|%%14609|
+||LayerRTID|integer|Windows Filtering Platform layer identifier.|40|
 
 ## Reference
 

--- a/data_dictionaries/windows/security/events/event-5154.md
+++ b/data_dictionaries/windows/security/events/event-5154.md
@@ -1,0 +1,22 @@
+# Event ID 5154: The Windows Filtering Platform has permitted an application or service to listen on a port for incoming connections
+
+## Description
+
+This event generates every time Windows Filtering Platform permits an application or service to listen on a port.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+|process_id|ProcessId|Pointer|hexadecimal Process ID of the process which was permitted to listen on the port.|4152|
+|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application requested to listen on the port.|0.0.0.0|
+|src_port|SourcePort|UnicodeString|Source TCP\UDP port number which was requested for listening by application.|44|
+||Protocol|UInt32|Protocol number.|6|
+||FilterRTID|UInt64|Unique filter ID which allows application to listen on the specific port.|0|
+||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
+||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5154.md)

--- a/data_dictionaries/windows/security/events/event-5155.md
+++ b/data_dictionaries/windows/security/events/event-5155.md
@@ -1,0 +1,22 @@
+# Event ID 5155: The Windows Filtering Platform has blocked an application or service from listening on a port for incoming connections
+
+## Description
+
+This event generates every time the Windows Filtering Platform blocks an application or service from listening on a port for incoming connections.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+|process_id|ProcessId|Pointer|Hexadecimal Process ID (PID) of the process which was permitted to bind to the local port.|2628|
+|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
+|src_ip_addr|SourceAddress|UnicodeString|The local IP address of the computer running the application.|0.0.0.0|
+|src_port|SourcePort|UnicodeString|The port number used by the application.|5555|
+||Protocol|UInt32|Protocol number.|6|
+||FilterRTID|UInt64|A unique filter ID which blocks the application from binding to the port.|84576|
+||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
+||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5155.md)

--- a/data_dictionaries/windows/security/events/event-5155.md
+++ b/data_dictionaries/windows/security/events/event-5155.md
@@ -9,10 +9,10 @@ This event generates every time the Windows Filtering Platform blocks an applica
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 |process_id|ProcessId|Pointer|Hexadecimal Process ID (PID) of the process which was permitted to bind to the local port.|2628|
-|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
+|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
 |src_ip_addr|SourceAddress|UnicodeString|The local IP address of the computer running the application.|0.0.0.0|
 |src_port|SourcePort|UnicodeString|The port number used by the application.|5555|
-||Protocol|UInt32|Protocol number.|6|
+|network_protocol|Protocol|UInt32|Protocol number.|6|
 ||FilterRTID|UInt64|A unique filter ID which blocks the application from binding to the port.|84576|
 ||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
 ||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|

--- a/data_dictionaries/windows/security/events/event-5155.md
+++ b/data_dictionaries/windows/security/events/event-5155.md
@@ -8,14 +8,14 @@ This event generates every time the Windows Filtering Platform blocks an applica
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-|process_id|ProcessId|Pointer|Hexadecimal Process ID (PID) of the process which was permitted to bind to the local port.|2628|
-|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
-|src_ip_addr|SourceAddress|UnicodeString|The local IP address of the computer running the application.|0.0.0.0|
-|src_port|SourcePort|UnicodeString|The port number used by the application.|5555|
-|network_protocol|Protocol|UInt32|Protocol number.|6|
-||FilterRTID|UInt64|A unique filter ID which blocks the application from binding to the port.|84576|
-||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
-||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|
+|process_id|ProcessId|integer|Hexadecimal Process ID (PID) of the process which was permitted to bind to the local port.|2628|
+|process_path|Application|string|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
+|src_ip_addr|SourceAddress|ip|The local IP address of the computer running the application.|0.0.0.0|
+|src_port|SourcePort|integer|The port number used by the application.|5555|
+|network_protocol|Protocol|integer|Protocol number.|6|
+||FilterRTID|integer|A unique filter ID which blocks the application from binding to the port.|84576|
+||LayerName|string|Application Layer Enforcement layer name.|%%14609|
+||LayerRTID|integer|Windows Filtering Platform layer identifier.|40|
 
 ## Reference
 

--- a/data_dictionaries/windows/security/events/event-5156.md
+++ b/data_dictionaries/windows/security/events/event-5156.md
@@ -9,13 +9,13 @@ This event generates when Windows Filtering Platform has allowed a connection.
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 |process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which received the connection.|4156|
-|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
 ||Direction|UnicodeString|Direction of allowed connection.|Inbound|
 |src_ip_addr|SourceAddress|UnicodeString|IP address from which the connection was initiated.|10.0.0.10|
 |src_port|SourcePort|UnicodeString|Port number from which the connection was initiated.|3333|
 |dst_ip_addr|DestAddress|UnicodeString|IP address where the connection was received.|10.0.0.100|
 |dst_port|DestPort|UnicodeString|Port number where the connection was received.|49278|
-||Protocol|UInt32|Protocol number.|6|
+|network_protocol|Protocol|UInt32|Protocol number.|6|
 ||FilterRTID|UInt64|Unique filter ID which allowed the connection.|84576|
 ||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
 ||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|

--- a/data_dictionaries/windows/security/events/event-5156.md
+++ b/data_dictionaries/windows/security/events/event-5156.md
@@ -8,17 +8,17 @@ This event generates when Windows Filtering Platform has allowed a connection.
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which received the connection.|4156|
-|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
-||Direction|UnicodeString|Direction of allowed connection.|Inbound|
-|src_ip_addr|SourceAddress|UnicodeString|IP address from which the connection was initiated.|10.0.0.10|
-|src_port|SourcePort|UnicodeString|Port number from which the connection was initiated.|3333|
-|dst_ip_addr|DestAddress|UnicodeString|IP address where the connection was received.|10.0.0.100|
-|dst_port|DestPort|UnicodeString|Port number where the connection was received.|49278|
-|network_protocol|Protocol|UInt32|Protocol number.|6|
-||FilterRTID|UInt64|Unique filter ID which allowed the connection.|84576|
-||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
-||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|
+|process_id|ProcessId|integer|Hexadecimal Process ID of the process which received the connection.|4156|
+|process_path|Application|string|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+||Direction|string|Direction of allowed connection.|Inbound|
+|src_ip_addr|SourceAddress|ip|IP address from which the connection was initiated.|10.0.0.10|
+|src_port|SourcePort|integer|Port number from which the connection was initiated.|3333|
+|dst_ip_addr|DestAddress|ip|IP address where the connection was received.|10.0.0.100|
+|dst_port|DestPort|integer|Port number where the connection was received.|49278|
+|network_protocol|Protocol|integer|Protocol number.|6|
+||FilterRTID|integer|Unique filter ID which allowed the connection.|84576|
+||LayerName|string|Application Layer Enforcement layer name.|%%14609|
+||LayerRTID|integer|Windows Filtering Platform layer identifier.|40|
 ||RemoteUserID|||S-1-0-0|
 ||RemoteMachineID|||S-1-0-0|
 

--- a/data_dictionaries/windows/security/events/event-5156.md
+++ b/data_dictionaries/windows/security/events/event-5156.md
@@ -1,0 +1,27 @@
+# Event ID 5156: The Windows Filtering Platform has permitted a connection
+
+## Description
+
+This event generates when Windows Filtering Platform has allowed a connection.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which received the connection.|4156|
+|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+||Direction|UnicodeString|Direction of allowed connection.|Inbound|
+|src_ip_addr|SourceAddress|UnicodeString|IP address from which the connection was initiated.|10.0.0.10|
+|src_port|SourcePort|UnicodeString|Port number from which the connection was initiated.|3333|
+|dst_ip_addr|DestAddress|UnicodeString|IP address where the connection was received.|10.0.0.100|
+|dst_port|DestPort|UnicodeString|Port number where the connection was received.|49278|
+||Protocol|UInt32|Protocol number.|6|
+||FilterRTID|UInt64|Unique filter ID which allowed the connection.|84576|
+||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14609|
+||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|40|
+||RemoteUserID|||S-1-0-0|
+||RemoteMachineID|||S-1-0-0|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5156.md)

--- a/data_dictionaries/windows/security/events/event-5157.md
+++ b/data_dictionaries/windows/security/events/event-5157.md
@@ -8,17 +8,17 @@ This event generates when Windows Filtering Platform has blocked a connection.
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process that attempted to create the connection.|4556|
-|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
-||Direction|UnicodeString|Direction of blocked connection.|Inbound|
-|src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application received the connection.|10.0.0.10|
-|src_port|SourcePort|UnicodeString|Port number on which application received the connection.|3333|
-|dst_ip_addr|DestAddress|UnicodeString|IP address from which connection was received or initiated.|10.0.0.100|
-|dst_port|DestPort|UnicodeString|Port number which was used from remote machine to initiate connection.|49218|
-|network_protocol|Protocol|UInt32|Protocol number.|6|
-||FilterRTID|UInt64|Unique filter ID which blocked the connection.|110398|
-||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14610|
-||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|44|
+|process_id|ProcessId|integer|Hexadecimal Process ID of the process that attempted to create the connection.|4556|
+|process_path|Application|string|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+||Direction|string|Direction of blocked connection.|Inbound|
+|src_ip_addr|SourceAddress|ip|Local IP address on which application received the connection.|10.0.0.10|
+|src_port|SourcePort|integer|Port number on which application received the connection.|3333|
+|dst_ip_addr|DestAddress|ip|IP address from which connection was received or initiated.|10.0.0.100|
+|dst_port|DestPort|integer|Port number which was used from remote machine to initiate connection.|49218|
+|network_protocol|Protocol|integer|Protocol number.|6|
+||FilterRTID|integer|Unique filter ID which blocked the connection.|110398|
+||LayerName|string|Application Layer Enforcement layer name.|%%14610|
+||LayerRTID|integer|Windows Filtering Platform layer identifier.|44|
 ||RemoteUserID|||S-1-0-0|
 ||RemoteMachineID|||S-1-0-0|
 

--- a/data_dictionaries/windows/security/events/event-5157.md
+++ b/data_dictionaries/windows/security/events/event-5157.md
@@ -9,13 +9,13 @@ This event generates when Windows Filtering Platform has blocked a connection.
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 |process_id|ProcessId|Pointer|Hexadecimal Process ID of the process that attempted to create the connection.|4556|
-|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
 ||Direction|UnicodeString|Direction of blocked connection.|Inbound|
 |src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application received the connection.|10.0.0.10|
 |src_port|SourcePort|UnicodeString|Port number on which application received the connection.|3333|
 |dst_ip_addr|DestAddress|UnicodeString|IP address from which connection was received or initiated.|10.0.0.100|
 |dst_port|DestPort|UnicodeString|Port number which was used from remote machine to initiate connection.|49218|
-||Protocol|UInt32|Protocol number.|6|
+|network_protocol|Protocol|UInt32|Protocol number.|6|
 ||FilterRTID|UInt64|Unique filter ID which blocked the connection.|110398|
 ||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14610|
 ||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|44|

--- a/data_dictionaries/windows/security/events/event-5157.md
+++ b/data_dictionaries/windows/security/events/event-5157.md
@@ -1,0 +1,27 @@
+# Event ID 5157: The Windows Filtering Platform has permitted a connection
+
+## Description
+
+This event generates when Windows Filtering Platform has blocked a connection.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process that attempted to create the connection.|4556|
+|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+||Direction|UnicodeString|Direction of blocked connection.|Inbound|
+|src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application received the connection.|10.0.0.10|
+|src_port|SourcePort|UnicodeString|Port number on which application received the connection.|3333|
+|dst_ip_addr|DestAddress|UnicodeString|IP address from which connection was received or initiated.|10.0.0.100|
+|dst_port|DestPort|UnicodeString|Port number which was used from remote machine to initiate connection.|49218|
+||Protocol|UInt32|Protocol number.|6|
+||FilterRTID|UInt64|Unique filter ID which blocked the connection.|110398|
+||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14610|
+||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|44|
+||RemoteUserID|||S-1-0-0|
+||RemoteMachineID|||S-1-0-0|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5157.md)

--- a/data_dictionaries/windows/security/events/event-5158.md
+++ b/data_dictionaries/windows/security/events/event-5158.md
@@ -8,14 +8,14 @@ This event generates every time Windows Filtering Platform permits an applicatio
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|4556|
-|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
-|src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application was bind the port.|0.0.0.0|
-|src_port|SourcePort|UnicodeString|Port number which application was bind.|3333|
-|network_protocol|Protocol|UInt32|Protocol number.|6|
-||FilterRTID|UInt64|Unique filter ID which allows application to bind the port.|0|
-||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14608|
-||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|36|
+|process_id|ProcessId|integer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|4556|
+|process_path|Application|string|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|src_ip_addr|SourceAddress|ip|Local IP address on which application was bind the port.|0.0.0.0|
+|src_port|SourcePort|integer|Port number which application was bind.|3333|
+|network_protocol|Protocol|integer|Protocol number.|6|
+||FilterRTID|integer|Unique filter ID which allows application to bind the port.|0|
+||LayerName|string|Application Layer Enforcement layer name.|%%14608|
+||LayerRTID|integer|Windows Filtering Platform layer identifier.|36|
 
 ## Reference
 

--- a/data_dictionaries/windows/security/events/event-5158.md
+++ b/data_dictionaries/windows/security/events/event-5158.md
@@ -9,10 +9,10 @@ This event generates every time Windows Filtering Platform permits an applicatio
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 |process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|4556|
-|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
 |src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application was bind the port.|0.0.0.0|
 |src_port|SourcePort|UnicodeString|Port number which application was bind.|3333|
-||Protocol|UInt32|Protocol number.|6|
+|network_protocol|Protocol|UInt32|Protocol number.|6|
 ||FilterRTID|UInt64|Unique filter ID which allows application to bind the port.|0|
 ||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14608|
 ||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|36|

--- a/data_dictionaries/windows/security/events/event-5158.md
+++ b/data_dictionaries/windows/security/events/event-5158.md
@@ -1,0 +1,22 @@
+# Event ID 5158: The Windows Filtering Platform has permitted a bind to a local port
+
+## Description
+
+This event generates every time Windows Filtering Platform permits an application or service to bind to a local port.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|4556|
+|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\\device\\harddiskvolume2\\documents\\listener.exe|
+|src_ip_addr|SourceAddress|UnicodeString|Local IP address on which application was bind the port.|0.0.0.0|
+|src_port|SourcePort|UnicodeString|Port number which application was bind.|3333|
+||Protocol|UInt32|Protocol number.|6|
+||FilterRTID|UInt64|Unique filter ID which allows application to bind the port.|0|
+||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14608|
+||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|36|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5158.md)

--- a/data_dictionaries/windows/security/events/event-5159.md
+++ b/data_dictionaries/windows/security/events/event-5159.md
@@ -9,10 +9,10 @@ This event is logged if the Windows Filtering Platform has blocked a bind to a l
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
 |process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|7924|
-|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
+|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
 |src_ip_addr|SourceAddress|UnicodeString|The local IP address of the computer running the application.|0.0.0.0|
 |src_port|SourcePort|UnicodeString|The port number used by the application.|5555|
-||Protocol|UInt32|Protocol number.|6|
+|network_protocol|Protocol|UInt32|Protocol number.|6|
 ||FilterRTID|UInt64|Unique filter ID which blocks the application from binding to the port.|84614|
 ||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14608|
 ||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|36|

--- a/data_dictionaries/windows/security/events/event-5159.md
+++ b/data_dictionaries/windows/security/events/event-5159.md
@@ -8,14 +8,14 @@ This event is logged if the Windows Filtering Platform has blocked a bind to a l
 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |----------------|----------------|----------------|----------------|----------------|
-|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|7924|
-|process_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
-|src_ip_addr|SourceAddress|UnicodeString|The local IP address of the computer running the application.|0.0.0.0|
-|src_port|SourcePort|UnicodeString|The port number used by the application.|5555|
-|network_protocol|Protocol|UInt32|Protocol number.|6|
-||FilterRTID|UInt64|Unique filter ID which blocks the application from binding to the port.|84614|
-||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14608|
-||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|36|
+|process_id|ProcessId|integer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|7924|
+|process_path|Application|string|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
+|src_ip_addr|SourceAddress|ip|The local IP address of the computer running the application.|0.0.0.0|
+|src_port|SourcePort|integer|The port number used by the application.|5555|
+|network_protocol|Protocol|integer|Protocol number.|6|
+||FilterRTID|integer|Unique filter ID which blocks the application from binding to the port.|84614|
+||LayerName|string|Application Layer Enforcement layer name.|%%14608|
+||LayerRTID|integer|Windows Filtering Platform layer identifier.|36|
 
 ## Reference
 

--- a/data_dictionaries/windows/security/events/event-5159.md
+++ b/data_dictionaries/windows/security/events/event-5159.md
@@ -1,0 +1,22 @@
+# Event ID 5159: The Windows Filtering Platform has blocked a bind to a local port.
+
+## Description
+
+This event is logged if the Windows Filtering Platform has blocked a bind to a local port.
+
+## Data Dictionary
+
+|Standard Name|Field Name|Type|Description|Sample Value|
+|----------------|----------------|----------------|----------------|----------------|
+|process_id|ProcessId|Pointer|Hexadecimal Process ID of the process which was permitted to bind to the local port.|7924|
+|file_path|Application|UnicodeString|Full path and the name of the executable for the process.|\device\harddiskvolume2\users\test\desktop\netcat\nc.exe|
+|src_ip_addr|SourceAddress|UnicodeString|The local IP address of the computer running the application.|0.0.0.0|
+|src_port|SourcePort|UnicodeString|The port number used by the application.|5555|
+||Protocol|UInt32|Protocol number.|6|
+||FilterRTID|UInt64|Unique filter ID which blocks the application from binding to the port.|84614|
+||LayerName|UnicodeString|Application Layer Enforcement layer name.|%%14608|
+||LayerRTID|UInt64|Windows Filtering Platform layer identifier.|36|
+
+## Reference
+
+[MS Source](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/auditing/event-5159.md)

--- a/data_dictionaries/windows/security/object_access/filtering_platform_connection/README.md
+++ b/data_dictionaries/windows/security/object_access/filtering_platform_connection/README.md
@@ -12,12 +12,12 @@ This subcategory contains Windows Filtering Platform events about blocked and al
 
 | EventId | Description | Minimum OS |
 |--------|---------|-------|
-| 5031 | The Windows Firewall Service blocked an application from accepting incoming connections on the network. |  |
+|[5031](/data_dictionaries/windows/security/events/event-5031.md)| The Windows Firewall Service blocked an application from accepting incoming connections on the network.|Windows 10, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012|
 | 5150 | The Windows Filtering Platform blocked a packet. | |
 | 5151 | A more restrictive Windows Filtering Platform filter has blocked a packet. |  |
-| 5154 | The Windows Filtering Platform has permitted an application or service to listen on a port for incoming connections. |  |
-| 5155 | The Windows Filtering Platform has blocked an application or service from listening on a port for incoming connections. |  |
-| 5156 | The Windows Filtering Platform has permitted a connection. |  |
-| 5157 | The Windows Filtering Platform has blocked a connection. |  |
-| 5158 | The Windows Filtering Platform has permitted a bind to a local port. |  |
-| 5159 | The Windows Filtering Platform has blocked a bind to a local port. |  |
+|[5154](/data_dictionaries/windows/security/events/event-5154.md) | The Windows Filtering Platform has permitted an application or service to listen on a port for incoming connections.|Windows 10, Windows Server 2016|
+|[5155](/data_dictionaries/windows/security/events/event-5155.md)| The Windows Filtering Platform has blocked an application or service from listening on a port for incoming connections.|Windows 10, Windows Server 2016|
+|[5156](/data_dictionaries/windows/security/events/event-5156.md)| The Windows Filtering Platform has permitted a connection.|Windows 10, Windows Server 2016|
+|[5157](/data_dictionaries/windows/security/events/event-5157.md)| The Windows Filtering Platform has blocked a connection.|Windows 10, Windows Server 2016|
+|[5158](/data_dictionaries/windows/security/events/event-5158.md)| The Windows Filtering Platform has permitted a bind to a local port.|Windows 10, Windows Server 2016|
+|[5159](/data_dictionaries/windows/security/events/event-5159.md)| The Windows Filtering Platform has blocked a bind to a local port.|Windows 10, Windows Server 2016|


### PR DESCRIPTION
Please note that I've slightly changed the markdown schema in these entries. I've removed the headers for 'Event Log Illustration & Event XML', and moved the provider url link to a reference header in the bottom of the page.