### PR TITLE
Sysmon11 4.30

### DIFF
--- a/data_dictionaries/windows/sysmon/events/event-1.md
+++ b/data_dictionaries/windows/sysmon/events/event-1.md
@@ -10,7 +10,6 @@ The process creation event provides extended information about a newly created p
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|ProcessGuid|string|Process Guid of the process that got spawned/created (child)|`{A98268C1-9C2E-5ACD-0000-0010396CAB00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the created process (child)|`4756`|
-|process_name|Image|string|The name of the executable without full path related to the process being spawned/created in the event. Considered also the child or source process|`conhost.exe`|
 |process_path|Image|string|File path of the process being spawned/created. Considered also the child or source process|`C:\Windows\System32\conhost.exe`|
 |file_version|FileVersion|string|Version of the image associated with the main process (child)|`10.0.16299.15 (WinBuild.160101.0800)`|
 |file_description|Description|string|Description of the image associated with the main process (child)|`Console Window Host`|
@@ -24,10 +23,9 @@ The process creation event provides extended information about a newly created p
 |user_logon_id|LogonId|integer|Login ID of the user who created the new process. Value that can help you correlate this event with others that contain the same Logon ID|`0xf6219`|
 |user_session_id|TerminalSessionId|integer|ID of the session the user belongs to|`1`|
 |process_integrity_level|IntegrityLevel|string|Integrity label assigned to a process|`Medium`|
-|hash|Hashes|string|Hashes captured by sysmon driver|`SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7, SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B`|
+|TBD|Hashes|string|Hashes captured by sysmon driver|`SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7, SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B`|
 |process_parent_guid|ParentProcessGuid|string|ProcessGUID of the process that spawned/created the main process (child)|`{A98268C1-9C2E-5ACD-0000-00100266AB00}`|
 |process_parent_id|ParentProcessId|integer|Process ID of the process that spawned/created the main process (child)|`240`|
-|process_parent_name|ParentImage|string|The name of the executable related to the target process|`cmd.exe`|
 |process_parent_path|ParentImage|string|File path that spawned/created the main process|`C:\Windows\System32\cmd.exe`|
 |process_parent_command_line|ParentCommandLine|string|Arguments which were passed to the executable associated with the parent process|`C:\WINDOWS\system32\cmd.exe`|
 

--- a/data_dictionaries/windows/sysmon/events/event-10.md
+++ b/data_dictionaries/windows/sysmon/events/event-10.md
@@ -11,11 +11,9 @@ The process accessed event reports when a process opens another process, an oper
 |process_guid|SourceProcessGuid|string|Process Guid of the source process that opened another process. It is derived from a truncated part of the machine GUID, the process start-time and the process token ID.|`{A98268C1-9587-5ACD-0000-001004C40000}`|
 |process_id|SourceProcessId|integer|Process ID used by the os to identify the source process that opened another process. Derived partially from the EPROCESS kernel structure|`916`|
 |thread_id|SourceThreadId|integer|ID of the specific thread inside of the source process that opened another process|`2804`|
-|process_name|SourceImage|string|The name of the executable for the source process that created a thread in another process|`svchost.exe`|
 |process_path|SourceImage|string|File path of the source process that created a thread in another process|`C:\WINDOWS\system32\svchost.exe`|
 |target_process_guid|TargetProcessGuid|string|Process Guid of the target process|`{A98268C1-9597-5ACD-0000-00101D690200}`|
 |target_process_id|TargetProcessId|integer|Process ID used by the os to identify the target process|`2288`|
-|target_process_name|TargetImage|string|The name of the executable of the target process|`4.12.17007.18022-0\MsMpEng.exe`|
 |target_process_path|TargetImage|string|File path of the target process|`C:\ProgramData\Microsoft\Windows Defender\platform\4.12.17007.18022-0\MsMpEng.exe`|
 |process_granted_access|GrantedAccess|string|The access flags (bitmask) associated with the process rights requested for the target process|`0x1000`|
 |process_call_trace|CallTrace|string|Stack trace of where open process is called. Included is the DLL and the relative virtual address of the functions in the call stack right before the open process call|`C:\WINDOWS\SYSTEM32\ntdll.dll+a0344`|

--- a/data_dictionaries/windows/sysmon/events/event-11.md
+++ b/data_dictionaries/windows/sysmon/events/event-11.md
@@ -10,7 +10,6 @@ File create operations are logged when a file is created or overwritten. This ev
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:01`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created the file|`{A98268C1-958A-5ACD-0000-0010C62F0100}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the file (child)|`1044`|
-|process_name|Image|string|File name of the process that created the file|`svchost.exe`|
 |process_path|Image|string|File path of the process that created the file|`C:\WINDOWS\System32\svchost.exe`|
 |file_name|TargetFilename|string|Name of the file|`C:\Windows\Prefetch\CONHOST.EXE-1F3E9D7E.pf`|
 |file_date_creation|CreationUtcTime|date|File creation time|`12/4/17 17:38`|

--- a/data_dictionaries/windows/sysmon/events/event-12.md
+++ b/data_dictionaries/windows/sysmon/events/event-12.md
@@ -11,7 +11,6 @@ Registry key and value create and delete operations map to this event type, whic
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created or deleted a registry key|`{A98268C1-9595-5ACD-0000-0010C2380200}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created or deleted a registry key|`2052`|
-|process_name|Image|string|File name of the process that created or deleted a registry key|`OfficeClickToRun.exe`|
 |process_path|Image|string|File path of the process that created or deleted a registry key|`C:\Program Files\Common Files\Microsoft Shared\ClickToRun\OfficeClickToRun.exe`|
 |registry_key_path|TargetObject|string|complete path of the registry key|`HKU.DEFAULT\Software\Microsoft\Office\16.0\Common`|
 

--- a/data_dictionaries/windows/sysmon/events/event-13.md
+++ b/data_dictionaries/windows/sysmon/events/event-13.md
@@ -11,7 +11,6 @@ This Registry event type identifies Registry value modifications. The event reco
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:04`|
 |process_guid|ProcessGuid|string|Process Guid of the process that modified a registry value|`{A98268C1-95F9-5ACD-0000-001025861000}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that that modified a registry value|`4624`|
-|process_name|Image|string|File name of the process that that modified a registry value|`Explorer.EXE`|
 |process_path|Image|string|File path of the process that that modified a registry value|`C:\WINDOWS\Explorer.EXE`|
 |registry_key_path|TargetObject|string|complete path of the registry key|`HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Notifications\Data\418A073AA3BC3475`|
 |registry_key_details|Details|string|Details added to the registry key|`Binary Data`|

--- a/data_dictionaries/windows/sysmon/events/event-14.md
+++ b/data_dictionaries/windows/sysmon/events/event-14.md
@@ -11,7 +11,6 @@ Registry key and value rename operations map to this event type, recording the n
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:04`|
 |process_guid|ProcessGuid|string|Process Guid of the process that renamed a registry value and key|`{A98268C1-95F9-5ACD-0000-001025861000}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that renamed a registry value and key|`4624`|
-|process_name|Image|string|File name of the process that renamed a registry value and key|`Explorer.EXE`|
 |process_path|Image|string|File path of the process that renamed a registry value and key|`C:\WINDOWS\Explorer.EXE`|
 |registry_key_path|TargetObject|string|complete path of the registry key|`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\New Key #1`|
 |registry_key_new_name|NewName|string|new name of the registry key|`\REGISTRY\MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\hello`|

--- a/data_dictionaries/windows/sysmon/events/event-15.md
+++ b/data_dictionaries/windows/sysmon/events/event-15.md
@@ -10,11 +10,10 @@ This event logs when a named file stream is created, and it generates events tha
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created the named file stream|`{A98268C1-A8A0-5ACD-0000-001087DEBF00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the named file stream|`6972`|
-|process_name|Image|string|File name of the process that created the named file stream|`chrome.exe`|
 |process_path|Image|string|File path of the process that created the named file stream|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|
 |file_name|TargetFilename|string|Name of the file|`C:\Users\wardog\Downloads\a0fa35bc5badf505f803921f0fe40971-4cf6bad280c7b66e21bb8e96ffe2f968ca460e0d.zip:Zone.Identifier`|
 |file_creation_time|CreationUtcTime|date|File download time|`4/11/18 6:18`|
-|hash|Hash|string|hash is a full hash of the file with the algorithms in the HashType field|`SHA1=F897DA14CF93C872CE821F549C34B848E345C8AC, MD5=697C69E7BB023075F14BC0BE25B875D8, SHA256=3157F3E7A854A13A40FFC79472C319E5B7C744B50D869D6E45F40CD4218539C5, IMPHASH=00000000000000000000000000000000`|
+|TBD|Hash|string|hash is a full hash of the file with the algorithms in the HashType field|`SHA1=F897DA14CF93C872CE821F549C34B848E345C8AC, MD5=697C69E7BB023075F14BC0BE25B875D8, SHA256=3157F3E7A854A13A40FFC79472C319E5B7C744B50D869D6E45F40CD4218539C5, IMPHASH=00000000000000000000000000000000`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-15-filecreatestreamhash)

--- a/data_dictionaries/windows/sysmon/events/event-17.md
+++ b/data_dictionaries/windows/sysmon/events/event-17.md
@@ -6,12 +6,12 @@ This event generates when a named pipe is created. Malware often uses named pipe
 ## Data Dictionary
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
+|event_type|EventType|string|TBD|`[CreatePipe]{.underline}`|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:21`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created the pipe|`{A98268C1-A968-5ACD-0000-0010BD4EC200}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the pipe|`1224`|
 |pipe_name|PipeName|string|Name of the pipe created|`Anonymous Pipe`|
-|process_name|Image|string|File name of the process that created the pipe|`cmd.exe`|
 |process_path|Image|string|File path of the process that created the pipe|`C:\WINDOWS\system32\cmd.exe`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-18.md
+++ b/data_dictionaries/windows/sysmon/events/event-18.md
@@ -6,12 +6,12 @@ This event logs when a named pipe connection is made between a client and a serv
 ## Data Dictionary
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
+|event_type|EventType|string|TBD|`[CreatePipe]{.underline}`|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:28`|
 |process_guid|ProcessGuid|string|Process Guid of the process that connected the pipe|`{A98268C1-959E-5ACD-0000-0010236E0300}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that connected the pipe|`1896`|
 |pipe_name|PipeName|string|Name of the pipe connecged|`\srvsvc`|
-|process_name|Image|string|File name of the process that connected the pipe|`wmiprvse.exe`|
 |process_path|Image|string|File path of the process that connected the pipe|`C:\WINDOWS\system32\wbem\wmiprvse.exe`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-2.md
+++ b/data_dictionaries/windows/sysmon/events/event-2.md
@@ -6,10 +6,10 @@ The change file creation time event is registered when a file creation time is e
 ## Data Dictionary
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
+|tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:04`|
 |process_guid|ProcessGuid|string|Process Guid of the process that changed the file creation time|`{A98268C1-975A-5ACD-0000-0010DB073A00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process changing the file creation time|`1252`|
-|process_name|Image|string|File name of the process that changed the file creation time|`powershell.exe`|
 |process_path|Image|string|File path of the process that changed the file creation time|`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`|
 |file_name|TargetFilename|string|full path name of the file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
 |file_date_creation|CreationUtcTime|date|new creation time of the file|`11/13/17 16:57`|

--- a/data_dictionaries/windows/sysmon/events/event-23.md
+++ b/data_dictionaries/windows/sysmon/events/event-23.md
@@ -1,0 +1,22 @@
+# Event ID 23: FileDelete (A file delete was detected)
+
+## Description
+This event logs when a file is deleted by a process.
+
+## Data Dictionary
+|Standard Name|Field Name|Type|Description|Sample Value|
+|---|---|---|---|---|
+|tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
+|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:28`|
+|process_guid|ProcessGuid|string|Process Guid of the process that deleted the file|`{A98268C1-959E-5ACD-0000-0010236E0300}`|
+|process_id|ProcessId|integer|Process ID used by the os to identify the process that deleted the file|`1896`|
+|process_path|Image|string|File path of the process that deleted the file|`C:\WINDOWS\system32\explorer.exe`|
+|user_name|User|string|Name of the account who deleted the file.|`DESKTOP-WARDOG\wardog`|
+|file_name|TargetFilename|string|full path name of the deleted file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
+|TBD|Hashes|string|Hashes captured by sysmon driver of the deleted file|`SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7, SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B`|
+|TBD|IsExecutable|bool|TBD|`TBD`|
+|TBD|Archived|string|States if the file was archived when deleted|`True`|
+
+## References
+* [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-23-filedelete-a-file-delete-was-detected)
+* [Sysmon 11 - FileDelete events](https://medium.com/falconforce/sysmon-11-dns-improvements-and-filedelete-events-7a74f17ca842)

--- a/data_dictionaries/windows/sysmon/events/event-3.md
+++ b/data_dictionaries/windows/sysmon/events/event-3.md
@@ -10,7 +10,6 @@ The network connection event logs TCP/UDP connections on the machine. It is disa
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:29`|
 |process_guid|ProcessGuid|string|Process Guid of the process that made the network connection|`{A98268C1-957F-5ACD-0000-0010EB030000}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that made the network connection|`4`|
-|process_name|Image|string|File name of the process that made the network connection|`System`|
 |process_path|Image|string|File path of the process that made the network connection|`System`|
 |user_name|User|string|Name of the account who made the network connection. It usually containes domain name and user name|`NT AUTHORITY\SYSTEM`|
 |network_protocol|Protocol|string|Protocol being used for the network connection|`udp`|

--- a/data_dictionaries/windows/sysmon/events/event-5.md
+++ b/data_dictionaries/windows/sysmon/events/event-5.md
@@ -10,7 +10,6 @@ The process terminate event reports when a process terminates. It provides the U
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:37`|
 |process_guid|ProcessGuid|string|Process Guid of the process that terminated|`{A98268C1-9ECD-5ACD-0000-0010EF6BAF00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that terminated|`2428`|
-|process_name|Image|string|The name of the executable of the process that terminated|`backgroundTaskHost.exe`|
 |process_path|Image|string|File path of the process that terminated|`C:\Windows\System32\backgroundTaskHost.exe`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-6.md
+++ b/data_dictionaries/windows/sysmon/events/event-6.md
@@ -9,7 +9,7 @@ The driver loaded events provides information about a driver being loaded on the
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:21`|
 |driver_loaded|ImageLoaded|string|full path of the driver loaded|`C:\ProgramData\Microsoft\Windows Defender\Definition Updates{741285CC-BF49-492C-90BE-E84BD6CADD73}\MpKsl4d223a5a.sys`|
-|hash|Hashes|string|Hashes captured by sysmon driver|`SHA1=38310AD6805DC31D5AA61BE182689D63060ACE94, MD5=BF2513029E231BE96D82F7C3ABFF87F4, SHA256=F6DB64112CC50EEE495E2D7C61B8BDBE757A31B03144B0396615FD38C312824E, IMPHASH=06D4A412CF7F5363C49E629BF34446B3`|
+|TBD|Hashes|string|Hashes captured by sysmon driver|`SHA1=38310AD6805DC31D5AA61BE182689D63060ACE94, MD5=BF2513029E231BE96D82F7C3ABFF87F4, SHA256=F6DB64112CC50EEE495E2D7C61B8BDBE757A31B03144B0396615FD38C312824E, IMPHASH=06D4A412CF7F5363C49E629BF34446B3`|
 |driver_is_signed|Signed|boolean|is the driver loaded signed|`TRUE`|
 |driver_signature|Signature|string|The signer|`Microsoft Corporation`|
 |driver_signature_status|SignatureStatus|string|status of the signature (i.e valid)|`Valid`|

--- a/data_dictionaries/windows/sysmon/events/event-7.md
+++ b/data_dictionaries/windows/sysmon/events/event-7.md
@@ -10,7 +10,6 @@ The image loaded event logs when a module is loaded in a specific process. This 
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:46`|
 |process_guid|ProcessGuid|string|Process Guid of the process that loaded the image|`{A98268C1-A12A-5ACD-0000-0010E4C8B300}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that loaded the image|`3532`|
-|process_name|Image|string|File name of the process that loaded the image|`cmd.exe`|
 |process_path|Image|string|File path of the process that loaded the image|`C:\Windows\System32\cmd.exe`|
 |module_loaded|ImageLoaded|string|full path of the image loaded|`C:\Windows\System32\msvcrt.dll`|
 |file_version|FileVersion|string|Version of the image loaded|`7.0.16299.125 (WinBuild.160101.0800)`|
@@ -18,7 +17,7 @@ The image loaded event logs when a module is loaded in a specific process. This 
 |file_product|Product|string|Product name the image loaded belongs to|`Microsoft® Windows® Operating System`|
 |file_company|Company|string|Company name the image loaded belongs to|`Microsoft Corporation`|
 |file_name_original|OriginalFileName|string|original file name|`?`|
-|hash|Hashes|string|hash is a full hash of the file with the algorithms in the HashType field|`SHA1=AEB9839D02C99A3E7EED1F12671C3F827221EDF8, MD5=68195105C7D9A2B5DF5BB82ECA521092, SHA256=556FF2B03495E2117223E5697B54253F30BD10ED3C67468947D79945168A624A, IMPHASH=C16CC99941EF5E18707133A2532B7D0C`|
+|TBD|Hashes|string|hash is a full hash of the file with the algorithms in the HashType field|`SHA1=AEB9839D02C99A3E7EED1F12671C3F827221EDF8, MD5=68195105C7D9A2B5DF5BB82ECA521092, SHA256=556FF2B03495E2117223E5697B54253F30BD10ED3C67468947D79945168A624A, IMPHASH=C16CC99941EF5E18707133A2532B7D0C`|
 |module_is_signed|Signed|boolean|is the image loaded signed|`TRUE`|
 |module_signature|Signature|string|The signer|`Microsoft Corporation`|
 |module_signature_status|SignatureStatus|string|status of the signature (i.e valid)|`Valid`|

--- a/data_dictionaries/windows/sysmon/events/event-8.md
+++ b/data_dictionaries/windows/sysmon/events/event-8.md
@@ -10,11 +10,9 @@ The CreateRemoteThread event detects when a process creates a thread in another 
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|SourceProcessGuid|string|Process Guid of the source process that created a thread in another process|`{A98268C1-9586-5ACD-0000-001070A20000}`|
 |process_id|SourceProcessId|integer|Process ID used by the os to identify the source process that created a thread in another process|`684`|
-|process_name|SourceImage|string|The name of the executable for the source process that created a thread in another process|`csrss.exe`|
 |process_path|SourceImage|string|File path of the source process that created a thread in another process|`C:\Windows\System32\csrss.exe`|
 |target_process_guid|TargetProcessGuid|string|Process Guid of the target process|`{A98268C1-9C2E-5ACD-0000-00100266AB00}`|
 |target_process_id|TargetProcessId|integer|Process ID used by the os to identify the target process|`240`|
-|target_process_name|TargetImage|string|File name of the target process|`cmd.exe`|
 |target_process_path|TargetImage|string|File path of the target process|`C:\Windows\System32\cmd.exe`|
 |thread_new_id|NewThreadId|integer|Id of the new thread created in the target process|`2336`|
 |thread_start_address|StartAddress|string|New thread start address|`0x00007FFA356A7E40`|

--- a/data_dictionaries/windows/sysmon/events/event-9.md
+++ b/data_dictionaries/windows/sysmon/events/event-9.md
@@ -10,7 +10,6 @@ The RawAccessRead event detects when a process conducts reading operations from 
 |event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:51`|
 |process_guid|ProcessGuid|string|Process Guid of the process that conducted reading operations from the drive|`{A98268C1-959B-5ACD-0000-0010EFD50200}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that conducted reading operations from the drive|`2708`|
-|process_name|Image|string|File name of the process that conducted reading operations from the drive|`svchost.exe`|
 |process_path|Image|string|File path of the process that conducted reading operations from the drive|`C:\Windows\System32\svchost.exe`|
 |target_device|Device|string|Target device|`\Device\HarddiskVolume2`|
 

--- a/source/data_dictionaries/windows/sysmon/events/event-1.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-1.yml
@@ -32,13 +32,6 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the created process (child)
   sample_value: '4756'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: The name of the executable without full path related to the process
-    being spawned/created in the event. Considered also the child or source process
-  sample_value: conhost.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image
@@ -125,7 +118,7 @@ event_fields:
   type: string
   description: Integrity label assigned to a process
   sample_value: Medium
-- standard_name: hash
+- standard_name: TBD
   standard_type: TBD
   name: Hashes
   type: string
@@ -144,12 +137,6 @@ event_fields:
   type: integer
   description: Process ID of the process that spawned/created the main process (child)
   sample_value: '240'
-- standard_name: process_parent_name
-  standard_type: TBD
-  name: ParentImage
-  type: string
-  description: The name of the executable related to the target process
-  sample_value: cmd.exe
 - standard_name: process_parent_path
   standard_type: TBD
   name: ParentImage

--- a/source/data_dictionaries/windows/sysmon/events/event-10.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-10.yml
@@ -45,13 +45,6 @@ event_fields:
   description: ID of the specific thread inside of the source process that opened
     another process
   sample_value: '2804'
-- standard_name: process_name
-  standard_type: TBD
-  name: SourceImage
-  type: string
-  description: The name of the executable for the source process that created a thread
-    in another process
-  sample_value: svchost.exe
 - standard_name: process_path
   standard_type: TBD
   name: SourceImage
@@ -70,12 +63,6 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the target process
   sample_value: '2288'
-- standard_name: target_process_name
-  standard_type: TBD
-  name: TargetImage
-  type: string
-  description: The name of the executable of the target process
-  sample_value: 4.12.17007.18022-0\MsMpEng.exe
 - standard_name: target_process_path
   standard_type: TBD
   name: TargetImage

--- a/source/data_dictionaries/windows/sysmon/events/event-11.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-11.yml
@@ -32,12 +32,6 @@ event_fields:
   description: Process ID used by the os to identify the process that created the
     file (child)
   sample_value: '1044'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that created the file
-  sample_value: svchost.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-12.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-12.yml
@@ -37,12 +37,6 @@ event_fields:
   description: Process ID used by the os to identify the process that created or deleted
     a registry key
   sample_value: '2052'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that created or deleted a registry key
-  sample_value: OfficeClickToRun.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-13.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-13.yml
@@ -36,12 +36,6 @@ event_fields:
   description: Process ID used by the os to identify the process that that modified
     a registry value
   sample_value: '4624'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that that modified a registry value
-  sample_value: Explorer.EXE
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-14.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-14.yml
@@ -36,12 +36,6 @@ event_fields:
   description: Process ID used by the os to identify the process that renamed a registry
     value and key
   sample_value: '4624'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that renamed a registry value and key
-  sample_value: Explorer.EXE
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-15.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-15.yml
@@ -34,12 +34,6 @@ event_fields:
   description: Process ID used by the os to identify the process that created the
     named file stream
   sample_value: '6972'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that created the named file stream
-  sample_value: chrome.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image
@@ -58,7 +52,7 @@ event_fields:
   type: date
   description: File download time
   sample_value: 4/11/18 6:18
-- standard_name: hash
+- standard_name: TBD
   standard_type: TBD
   name: Hash
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-17.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-17.yml
@@ -5,6 +5,12 @@ platform: windows
 log_source: sysmon
 event_code: '17'
 event_fields:
+- standard_name: event_type
+  standard_type: TBD
+  name: EventType
+  type: string
+  description: TBD
+  sample_value: '[CreatePipe]{.underline}'
 - standard_name: tag
   standard_type: TBD
   name: RuleName
@@ -36,12 +42,6 @@ event_fields:
   type: string
   description: Name of the pipe created
   sample_value: Anonymous Pipe
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that created the pipe
-  sample_value: cmd.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-18.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-18.yml
@@ -5,6 +5,12 @@ platform: windows
 log_source: sysmon
 event_code: '18'
 event_fields:
+- standard_name: event_type
+  standard_type: TBD
+  name: EventType
+  type: string
+  description: TBD
+  sample_value: '[CreatePipe]{.underline}'
 - standard_name: tag
   standard_type: TBD
   name: RuleName
@@ -36,12 +42,6 @@ event_fields:
   type: string
   description: Name of the pipe connecged
   sample_value: \srvsvc
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that connected the pipe
-  sample_value: wmiprvse.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-2.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-2.yml
@@ -9,6 +9,12 @@ platform: windows
 log_source: sysmon
 event_code: '2'
 event_fields:
+- standard_name: tag
+  standard_type: TBD
+  name: RuleName
+  type: string
+  description: custom tag mapped to event. i.e ATT&CK technique ID
+  sample_value: T1114
 - standard_name: event_date_creation
   standard_type: TBD
   name: UtcTime
@@ -28,12 +34,6 @@ event_fields:
   description: Process ID used by the os to identify the process changing the file
     creation time
   sample_value: '1252'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that changed the file creation time
-  sample_value: powershell.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-23.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-23.yml
@@ -1,0 +1,73 @@
+title: 'Event ID 23: FileDelete (A file delete was detected)'
+description: This event logs when a file is deleted by a process.
+platform: windows
+log_source: sysmon
+event_code: '23'
+event_fields:
+- standard_name: tag
+  standard_type: TBD
+  name: RuleName
+  type: string
+  description: custom tag mapped to event. i.e ATT&CK technique ID
+  sample_value: T1114
+- standard_name: event_date_creation
+  standard_type: TBD
+  name: UtcTime
+  type: date
+  description: Time in UTC when event was created
+  sample_value: 4/11/18 6:28
+- standard_name: process_guid
+  standard_type: TBD
+  name: ProcessGuid
+  type: string
+  description: Process Guid of the process that deleted the file
+  sample_value: '{A98268C1-959E-5ACD-0000-0010236E0300}'
+- standard_name: process_id
+  standard_type: TBD
+  name: ProcessId
+  type: integer
+  description: Process ID used by the os to identify the process that deleted the file
+  sample_value: '1896'
+- standard_name: process_path
+  standard_type: TBD
+  name: Image
+  type: string
+  description: File path of the process that deleted the file
+  sample_value: C:\WINDOWS\system32\explorer.exe
+- standard_name: user_name
+  standard_type: TBD
+  name: User
+  type: string
+  description: Name of the account who deleted the file.
+  sample_value: DESKTOP-WARDOG\wardog
+- standard_name: file_name
+  standard_type: TBD
+  name: TargetFilename
+  type: string
+  description: full path name of the deleted file
+  sample_value: C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp
+- standard_name: TBD
+  standard_type: TBD
+  name: Hashes
+  type: string
+  description: Hashes captured by sysmon driver of the deleted file
+  sample_value: SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7,
+    SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B
+- standard_name: TBD
+  standard_type: TBD
+  name: IsExecutable
+  type: bool
+  description: TBD
+  sample_value: TBD
+- standard_name: TBD
+  standard_type: TBD
+  name: Archived
+  type: string
+  description: States if the file was archived when deleted
+  sample_value: Yes
+references:
+- text: Sysmon Source
+  link: https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-23-filedelete-a-file-delete-was-detected
+- text: Sysmon 11 - FileDelete events
+  link: https://medium.com/falconforce/sysmon-11-dns-improvements-and-filedelete-events-7a74f17ca842
+tags: []

--- a/source/data_dictionaries/windows/sysmon/events/event-3.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-3.yml
@@ -32,12 +32,6 @@ event_fields:
   description: Process ID used by the os to identify the process that made the network
     connection
   sample_value: '4'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that made the network connection
-  sample_value: System
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-5.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-5.yml
@@ -29,12 +29,6 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the process that terminated
   sample_value: '2428'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: The name of the executable of the process that terminated
-  sample_value: backgroundTaskHost.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image

--- a/source/data_dictionaries/windows/sysmon/events/event-6.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-6.yml
@@ -25,7 +25,7 @@ event_fields:
   type: string
   description: full path of the driver loaded
   sample_value: C:\ProgramData\Microsoft\Windows Defender\Definition Updates{741285CC-BF49-492C-90BE-E84BD6CADD73}\MpKsl4d223a5a.sys
-- standard_name: hash
+- standard_name: TBD
   standard_type: TBD
   name: Hashes
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-7.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-7.yml
@@ -33,12 +33,6 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the process that loaded the image
   sample_value: '3532'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that loaded the image
-  sample_value: cmd.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image
@@ -81,7 +75,7 @@ event_fields:
   type: string
   description: original file name
   sample_value: '?'
-- standard_name: hash
+- standard_name: TBD
   standard_type: TBD
   name: Hashes
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-8.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-8.yml
@@ -35,13 +35,6 @@ event_fields:
   description: Process ID used by the os to identify the source process that created
     a thread in another process
   sample_value: '684'
-- standard_name: process_name
-  standard_type: TBD
-  name: SourceImage
-  type: string
-  description: The name of the executable for the source process that created a thread
-    in another process
-  sample_value: csrss.exe
 - standard_name: process_path
   standard_type: TBD
   name: SourceImage
@@ -60,12 +53,6 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the target process
   sample_value: '240'
-- standard_name: target_process_name
-  standard_type: TBD
-  name: TargetImage
-  type: string
-  description: File name of the target process
-  sample_value: cmd.exe
 - standard_name: target_process_path
   standard_type: TBD
   name: TargetImage

--- a/source/data_dictionaries/windows/sysmon/events/event-9.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-9.yml
@@ -33,13 +33,6 @@ event_fields:
   description: Process ID used by the os to identify the process that conducted reading
     operations from the drive
   sample_value: '2708'
-- standard_name: process_name
-  standard_type: TBD
-  name: Image
-  type: string
-  description: File name of the process that conducted reading operations from the
-    drive
-  sample_value: svchost.exe
 - standard_name: process_path
   standard_type: TBD
   name: Image


### PR DESCRIPTION
This PR contains the updated Sysmon v11 schema 4.30 data dictionary, featuring the new event id 23 (file delete).

Additionally, the following fixes were made:
- Removed process_name related fields, as these are not part of the original sysmon schema, only process_paths (also known as Image).
- Removed the Hashes standard name from hashes fields, since it doesn't match any field in the Hash CIM entity.

Let me know if any changes are needed/typos/etc.