### PR TITLE
Fix spelling in Sysmon Network Connection event

### DIFF
--- a/data_dictionaries/windows/sysmon/events/event-3.md
+++ b/data_dictionaries/windows/sysmon/events/event-3.md
@@ -21,7 +21,7 @@ The network connection event logs TCP/UDP connections on the machine. It is disa
 |src_port_name|SourcePortName|string|name of the source port being used (i.e. netbios-dgm)|`netbios-dgm`|
 |dst_is_ipv6|DestinationIsIpv6|boolean|is the destination ip an Ipv6|`C:\Windows\System32\cmd.exe`|
 |dst_ip_addr|DestinationIp|ip|ip address destination|`192.168.64.135`|
-|dst_host_name|DestinationHostName|string|name of the host that received the network connection|`DC-WD-001`|
+|dst_host_name|DestinationHostname|string|name of the host that received the network connection|`DC-WD-001`|
 |dst_port|DestinationPort|integer|destination port number|`138`|
 |dst_port_name|DestinationPortName|string|name of the destination port|`netbios-dgm`|
 

--- a/source/data_dictionaries/windows/sysmon/events/event-3.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-3.yml
@@ -101,7 +101,7 @@ event_fields:
   sample_value: 192.168.64.135
 - standard_name: dst_host_name
   standard_type: TBD
-  name: DestinationHostName
+  name: DestinationHostname
   type: string
   description: name of the host that received the network connection
   sample_value: DC-WD-001


### PR DESCRIPTION
The actual field name is `DestinationHostname`, not `DestinationHostName`.